### PR TITLE
Update drag and drop to use shelf colliders

### DIFF
--- a/GoodSort/Assets/Scripts/GameCore/ItemView.cs
+++ b/GoodSort/Assets/Scripts/GameCore/ItemView.cs
@@ -62,17 +62,21 @@ namespace GameCore
             mouseWorld.z = 0f;
             Vector3 newPos = mouseWorld + m_dragOffset;
             transform.position = newPos;
+        }
 
-            // Raycast from the new item position
-            RaycastHit2D hit = Physics2D.Raycast(newPos, Vector2.down, Mathf.Infinity);
-
-            if (hit.collider != null)
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            ShelfView shelf = other.GetComponentInParent<ShelfView>();
+            if (shelf != null)
             {
-                ShelfView shelf = hit.collider.GetComponent<ShelfView>();
-                Debug.Log(shelf);
                 m_curShelfCollider = shelf;
             }
-            else
+        }
+
+        private void OnTriggerExit2D(Collider2D other)
+        {
+            ShelfView shelf = other.GetComponentInParent<ShelfView>();
+            if (shelf != null && shelf == m_curShelfCollider)
             {
                 m_curShelfCollider = null;
             }


### PR DESCRIPTION
## Summary
- drag items without raycast
- detect `ShelfView` via the slot colliders added to the prefab

## Testing
- `dotnet --version` *(fails: command not found)*