### PR TITLE
Refactor ShelfView with SlotView containers

### DIFF
--- a/GoodSort/Assets/Scripts/GameCore/MidSlotView.cs
+++ b/GoodSort/Assets/Scripts/GameCore/MidSlotView.cs
@@ -1,0 +1,6 @@
+namespace GameCore
+{
+    public class MidSlotView : SlotView
+    {
+    }
+}

--- a/GoodSort/Assets/Scripts/GameCore/MidSlotView.cs.meta
+++ b/GoodSort/Assets/Scripts/GameCore/MidSlotView.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 341be49a5374439aa5d719838c1649fc
+timeCreated: 1745249000

--- a/GoodSort/Assets/Scripts/GameCore/SlotView.cs
+++ b/GoodSort/Assets/Scripts/GameCore/SlotView.cs
@@ -1,0 +1,44 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GameCore
+{
+    public class SlotView : MonoBehaviour
+    {
+        private readonly List<ItemView> m_items = new List<ItemView>();
+        public IReadOnlyList<ItemView> Items => m_items;
+
+        public virtual void AddItem(ItemView item)
+        {
+            if (!m_items.Contains(item))
+            {
+                m_items.Add(item);
+                item.transform.SetParent(transform);
+                item.LayerIndex = m_items.Count;
+            }
+        }
+
+        public bool RemoveItem(ItemView item)
+        {
+            int index = m_items.IndexOf(item);
+            if (index >= 0)
+            {
+                m_items.RemoveAt(index);
+                RearrangeItems();
+                return true;
+            }
+            return false;
+        }
+
+        private void RearrangeItems()
+        {
+            for (int i = 0; i < m_items.Count; i++)
+            {
+                if (m_items[i] != null)
+                {
+                    m_items[i].LayerIndex = i + 1;
+                }
+            }
+        }
+    }
+}

--- a/GoodSort/Assets/Scripts/GameCore/SlotView.cs.meta
+++ b/GoodSort/Assets/Scripts/GameCore/SlotView.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 35eef0361b9f4c3896022fd6700fa617
+timeCreated: 1745249000


### PR DESCRIPTION
## Summary
- introduce `SlotView` and `MidSlotView` to manage shelf slots
- update `ItemView` to track its current shelf and slot
- refactor `ShelfView` to work with `SlotView` objects

## Testing
- `mcs` compilation not available, so code was not compiled