### PR TITLE
Improve item snapping logic

### DIFF
--- a/GoodSort/Assets/Scripts/View/ShelfView.cs
+++ b/GoodSort/Assets/Scripts/View/ShelfView.cs
@@ -146,15 +146,20 @@ namespace GameCore
 
         public void RemoveFromShelf(ItemController item)
         {
+            RemoveFromShelf(item, item.CurrentSlot);
+        }
+
+        public void RemoveFromShelf(ItemController item, SlotView slot)
+        {
             if (TopLayer.Contains(item))
             {
                 TopLayer.Remove(item);
-                if (item.CurrentSlot != null)
+                if (slot != null)
                 {
-                    item.CurrentSlot.RemoveItem(item);
-                    if (!m_availableSlots.Contains(item.CurrentSlot))
+                    slot.RemoveItem(item);
+                    if (!m_availableSlots.Contains(slot))
                     {
-                        m_availableSlots.Add(item.CurrentSlot);
+                        m_availableSlots.Add(slot);
                     }
                 }
                 if (TopLayer.Count == 0)
@@ -220,6 +225,12 @@ namespace GameCore
             }
 
             return nearest;
+        }
+
+        public bool TryGetSnapSlot(Vector3 worldPos, out SlotView slot)
+        {
+            slot = GetNearestAvailableSlot(worldPos);
+            return slot != null;
         }
 
         public bool TrySnapItem(ItemController item)


### PR DESCRIPTION
## Summary
- expose explicit slot removal from `ShelfView`
- add helper to query snap slots without side effects
- update item drop logic to remove from the old shelf before snapping

## Testing
- `git status --short`