### PR TITLE
Fix item snap offset

### DIFF
--- a/GoodSort/Assets/Scripts/View/SlotView.cs
+++ b/GoodSort/Assets/Scripts/View/SlotView.cs
@@ -14,6 +14,8 @@ namespace GameCore
         public virtual void AddItem(ItemController item)
         {
             item.transform.SetParent(transform);
+            // Reset local position so the item snaps exactly to the slot
+            item.transform.localPosition = Vector3.zero;
             item.LayerIndex = transform.childCount;
 
             if (m_slotData.itemsLists.Count == 0)


### PR DESCRIPTION
## Summary
- fix item snapping offset when adding to a slot

## Testing
- `dotnet test` *(fails: `dotnet` not found)*