### PR TITLE
Add top layer info to ShelfData

### DIFF
--- a/GoodSort/Assets/Scripts/Model/BoardModel.cs
+++ b/GoodSort/Assets/Scripts/Model/BoardModel.cs
@@ -10,6 +10,10 @@ namespace GameCore
         public BoardModel(LevelData_Flexible levelData)
         {
             shelfData = levelData.shelfList;
+            foreach (var shelf in shelfData)
+            {
+                shelf.UpdateTopItemIds();
+            }
         }
         
         private ShelfData GetShelfData(Vector2Int position) => shelfData.Find(x => x.position == position);
@@ -18,7 +22,7 @@ namespace GameCore
         {
             var shelfStartData = GetShelfData(shelfStart);
             var shelfEndData = GetShelfData(shelfEnd);
-            
+
             foreach (var slotData in shelfStartData.slotDatas)
             {
                 if (slotData.itemsLists[0] == itemId)
@@ -27,6 +31,7 @@ namespace GameCore
                     break;
                 }
             }
+            shelfStartData.UpdateTopItemIds();
 
             if (shelfStartData.IsFirstLayerEmpty)
             {
@@ -38,6 +43,7 @@ namespace GameCore
                     }
                     slotData.itemsLists.RemoveAt(0);
                 }
+                shelfStartData.UpdateTopItemIds();
             }
 
             bool added = false;
@@ -50,6 +56,7 @@ namespace GameCore
                     break;
                 }
             }
+            shelfEndData.UpdateTopItemIds();
 
             if (!added) return false;
 
@@ -69,6 +76,7 @@ namespace GameCore
                 {
                     slot.itemsLists[0] = -1;
                 }
+                shelfEndData.UpdateTopItemIds();
 
                 if (shelfEndData.IsFirstLayerEmpty)
                 {
@@ -79,6 +87,7 @@ namespace GameCore
                             slot.itemsLists.RemoveAt(0);
                         }
                     }
+                    shelfEndData.UpdateTopItemIds();
                 }
             }
 

--- a/GoodSort/Assets/Scripts/Model/GenLevelAlgorithm_Flexible.cs
+++ b/GoodSort/Assets/Scripts/Model/GenLevelAlgorithm_Flexible.cs
@@ -282,6 +282,7 @@ namespace DefaultNamespace
                     if (originalShelf.slotDatas != null && originalShelf.slotDatas.Count == 1 && originalShelf.slotDatas[0]?.itemsLists != null) newShelf.slotDatas.Add(new SlotData { itemsLists = new List<int>(originalShelf.slotDatas[0].itemsLists) });
                     else { Debug.LogError($"Dispenser shelf at pos {originalShelf.position} (index {i}) has invalid data."); newShelf.slotDatas.Add(new SlotData()); }
                 }
+                newShelf.UpdateTopItemIds();
                 finalShelfList.Add(newShelf);
             }
             return finalShelfList;
@@ -298,6 +299,7 @@ namespace DefaultNamespace
                  } else if (originalShelf.shelfType == ShelfType.Normal) {
                      for(int h=0; h<3; h++) { var items = new List<int>(numberOfLayersForEmptyNormal); for(int k=0; k<numberOfLayersForEmptyNormal; k++) items.Add(-1); newShelf.slotDatas.Add(new SlotData{ itemsLists = items }); }
                  }
+                 newShelf.UpdateTopItemIds();
                  finalShelfList.Add(newShelf);
              }
              return finalShelfList;

--- a/GoodSort/Assets/Scripts/Model/LevelData_Flexible.cs
+++ b/GoodSort/Assets/Scripts/Model/LevelData_Flexible.cs
@@ -155,16 +155,17 @@ public class LevelData_Flexible : ScriptableObject
     /// <summary>
     /// Sau khi dữ liệu level được tạo, loại bỏ các giá trị -1 ở các layer từ index 1 trở đi của mọi SlotData.
     /// </summary>
-    private void CleanupSlotData()
-    {
-        if (shelfList == null) return;
-        foreach (var shelf in shelfList)
+        private void CleanupSlotData()
         {
-            if (shelf.slotDatas == null) continue;
-            foreach (var slot in shelf.slotDatas)
+            if (shelfList == null) return;
+            foreach (var shelf in shelfList)
             {
-                slot?.RemoveNegativeFromIndexOne();
+                if (shelf.slotDatas == null) continue;
+                foreach (var slot in shelf.slotDatas)
+                {
+                    slot?.RemoveNegativeFromIndexOne();
+                }
+                shelf.UpdateTopItemIds();
             }
         }
-    }
 }

--- a/GoodSort/Assets/Scripts/Model/ShelfData.cs
+++ b/GoodSort/Assets/Scripts/Model/ShelfData.cs
@@ -41,21 +41,62 @@ namespace GameCore
         [InfoBox("Định nghĩa itemsLists cho Dispenser tại SlotData đầu tiên.", InfoMessageType.None, VisibleIf = "@this.shelfType == ShelfType.Dispenser && this.slotDatas != null && this.slotDatas.Count > 0")]
         public List<SlotData> slotDatas;
 
+        [Tooltip("ItemId trên cùng của mỗi SlotData. Index tương ứng với slotDatas.")]
+        [ListDrawerSettings(IsReadOnly = true)]
+        public List<int> topItemIds;
+
         // Constructor tiện lợi (tùy chọn)
         public ShelfData(ShelfType type, Vector2Int pos)
         {
             shelfType = type;
             position = pos;
             slotDatas = new List<SlotData>();
+            topItemIds = new List<int>();
+        }
+
+        public void UpdateTopItemIds()
+        {
+            if (topItemIds == null)
+            {
+                topItemIds = new List<int>();
+            }
+            topItemIds.Clear();
+            if (slotDatas == null)
+            {
+                return;
+            }
+
+            foreach (var slot in slotDatas)
+            {
+                int id = -1;
+                if (slot?.itemsLists != null && slot.itemsLists.Count > 0)
+                {
+                    id = slot.itemsLists[0];
+                }
+                topItemIds.Add(id);
+            }
         }
 
         public bool IsFirstLayerEmpty
         {
             get
             {
-                foreach (var slotData in slotDatas)
+                if (topItemIds == null || topItemIds.Count == 0)
                 {
-                    if (slotData.itemsLists[0] != -1)
+                    if (slotDatas == null) return true;
+                    foreach (var slotData in slotDatas)
+                    {
+                        if (slotData.itemsLists[0] != -1)
+                        {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+
+                foreach (var id in topItemIds)
+                {
+                    if (id != -1)
                     {
                         return false;
                     }


### PR DESCRIPTION
## Summary
- store the id of the top item for each slot inside `ShelfData`
- update board and level generation logic to maintain this list
- refresh the list when mutating shelves

## Testing
- `dotnet --version` *(fails: command not found)*