### PR TITLE
Update slot snapping logic

### DIFF
--- a/GoodSort/Assets/Scripts/Controller/ItemController.cs
+++ b/GoodSort/Assets/Scripts/Controller/ItemController.cs
@@ -61,19 +61,21 @@ namespace GameCore
 
             Vector2Int startPos = m_curShelf.Position;
 
-            // Find nearest slot that has MidSlotView
+            // Find nearest available slot based on top item id and shelf type
             MidSlotView nearestSlot = null;
             float minDist = m_snapDistance;
             foreach (var slot in FindObjectsOfType<MidSlotView>())
             {
+                if (!slot.CanSnap(Id))
+                {
+                    continue;
+                }
+
                 float dist = Vector3.Distance(transform.position, slot.transform.position);
                 if (dist <= minDist)
                 {
-                    if (slot.CanSnap(Id))
-                    {
-                        minDist = dist;
-                        nearestSlot = slot;
-                    }
+                    minDist = dist;
+                    nearestSlot = slot;
                 }
             }
 

--- a/GoodSort/Assets/Scripts/View/MidSlotView.cs
+++ b/GoodSort/Assets/Scripts/View/MidSlotView.cs
@@ -23,14 +23,20 @@ namespace GameCore
         /// <summary>
         ///     Returns true if the slot does not contain any item at layer 1.
         /// </summary>
-        public bool IsEmpty => SlotData.itemsLists.Count == 0 || SlotData.itemsLists[0] == -1;
+        public bool IsEmpty => TopItemId == -1;
 
         /// <summary>
         ///     Check if the slot can snap the given item id.
         /// </summary>
         public bool CanSnap(int itemId)
         {
-            if (!IsEmpty)
+            var shelf = GetComponentInParent<ShelfView>();
+            if (shelf == null || shelf.ShelfType != ShelfType.Normal)
+            {
+                return false;
+            }
+
+            if (TopItemId != -1)
             {
                 return false;
             }

--- a/GoodSort/Assets/Scripts/View/SlotView.cs
+++ b/GoodSort/Assets/Scripts/View/SlotView.cs
@@ -11,6 +11,21 @@ namespace GameCore
             set => m_slotData = value;
         }
 
+        /// <summary>
+        ///     Id of the item currently on top of this slot. -1 if empty.
+        /// </summary>
+        public int TopItemId
+        {
+            get
+            {
+                if (m_slotData.itemsLists == null || m_slotData.itemsLists.Count == 0)
+                {
+                    return -1;
+                }
+                return m_slotData.itemsLists[0];
+            }
+        }
+
         public virtual void AddItem(ItemController item)
         {
             item.transform.SetParent(transform);


### PR DESCRIPTION
## Summary
- expose `TopItemId` on `SlotView`
- restrict `MidSlotView.CanSnap` to shelves with `ShelfType.Normal` and empty top item
- search for snap targets in `ItemController` using updated `CanSnap`

## Testing
- `git status --short`