### PR TITLE
Update stack handling for slots

### DIFF
--- a/GoodSort/Assets/Scripts/Model/BoardModel.cs
+++ b/GoodSort/Assets/Scripts/Model/BoardModel.cs
@@ -27,7 +27,15 @@ namespace GameCore
             {
                 if (slotData.itemsLists[0] == itemId)
                 {
-                    slotData.itemsLists[0] = -1;
+                    if (slotData.itemsLists.Count == 1)
+                    {
+                        slotData.itemsLists[0] = -1;
+                    }
+                    else
+                    {
+                        slotData.itemsLists[0] = slotData.itemsLists[1];
+                        slotData.itemsLists.RemoveAt(1);
+                    }
                     break;
                 }
             }

--- a/GoodSort/Assets/Scripts/View/SlotView.cs
+++ b/GoodSort/Assets/Scripts/View/SlotView.cs
@@ -54,7 +54,15 @@ namespace GameCore
                 item.transform.SetParent(null);
                 if (m_slotData.itemsLists.Count > 0)
                 {
-                    m_slotData.itemsLists[0] = -1;
+                    if (m_slotData.itemsLists.Count == 1)
+                    {
+                        m_slotData.itemsLists[0] = -1;
+                    }
+                    else
+                    {
+                        m_slotData.itemsLists[0] = m_slotData.itemsLists[1];
+                        m_slotData.itemsLists.RemoveAt(1);
+                    }
                 }
                 RearrangeItems();
                 UpdateTopItemSlotVisibility();


### PR DESCRIPTION
## Summary
- shift SlotData items when removing items from SlotView
- keep BoardModel data in sync when items are removed from a slot

## Testing
- `npm test` *(fails: could not find package.json)*
- `dotnet test` *(fails: command not found)*