### PR TITLE
Adjust drag start condition

### DIFF
--- a/GoodSort/Assets/Scripts/Controller/ItemController.cs
+++ b/GoodSort/Assets/Scripts/Controller/ItemController.cs
@@ -40,7 +40,7 @@ namespace GameCore
 
         private void BeginDrag(Vector3 pointerWorldPosition)
         {
-            if (LayerIndex != 1)
+            if (m_curSlot == null || m_curSlot.TopItemSlot != gameObject)
             {
                 return;
             }


### PR DESCRIPTION
## Summary
- only allow dragging if this item is the slot's `TopItemSlot`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*