### PR TITLE
Clarify Item MVC separation

### DIFF
--- a/GoodSort/Assets/Scripts/Model/ItemData.cs
+++ b/GoodSort/Assets/Scripts/Model/ItemData.cs
@@ -1,12 +1,27 @@
 using System;
+using DefaultNamespace;
+using UnityEngine;
 
 namespace GameCore
 {
+    /// <summary>
+    /// Core data and basic logic for an item.
+    /// </summary>
     [Serializable]
     public class ItemData
     {
         public int id;
         public ItemVisualType visualType;
+
+        /// <summary>
+        /// Sprite associated with this item.
+        /// </summary>
+        public Sprite Icon => GameConfig.Instance.itemIconConfig.GetItemIconByID(id);
+
+        /// <summary>
+        /// True if the item should be fully visible on the board.
+        /// </summary>
+        public bool IsFullDisplay => visualType == ItemVisualType.FullDisplay;
     }
 
     [Serializable]

--- a/GoodSort/Assets/Scripts/View/ItemView.cs
+++ b/GoodSort/Assets/Scripts/View/ItemView.cs
@@ -15,8 +15,8 @@ namespace GameCore
         {
             if (m_icon != null)
             {
-                m_icon.sprite = GameConfig.Instance.itemIconConfig.GetItemIconByID(data.id);
-                m_icon.enabled = data.visualType == ItemVisualType.FullDisplay;
+                m_icon.sprite = data.Icon;
+                m_icon.enabled = data.IsFullDisplay;
             }
         }
 

--- a/GoodSort/Documentation/ItemMVC_Roles.md
+++ b/GoodSort/Documentation/ItemMVC_Roles.md
@@ -3,7 +3,7 @@
 Dưới đây là bản mô tả ngắn gọn về cách ba thành phần này hoạt động theo mô hình MVC trong dự án *GoodSort*.
 
 ## ItemData (Model)
-`ItemData` nằm trong thư mục **Model** và chỉ chứa dữ liệu về một item: ID của item và cách hiển thị (`ItemVisualType`). Lớp này không xử lý việc vẽ hay tương tác. Những hệ thống khác sẽ truy cập nó để đọc trạng thái của item một cách độc lập với UI.
+`ItemData` nằm trong thư mục **Model**. Ngoài các trường dữ liệu như ID và kiểu hiển thị (`ItemVisualType`), lớp này còn cung cấp một số logic cơ bản (ví dụ: trả về `Sprite` tương ứng từ `ItemIconConfig` và thuộc tính kiểm tra chế độ hiển thị). `ItemData` không trực tiếp xử lý việc vẽ hay tương tác UI, nhưng các lớp khác có thể dựa vào những thuộc tính này để hiển thị đúng thông tin.
 
 ## ItemView (View)
 `ItemView` thuộc thư mục **View**. Script này quản lý hình ảnh item trên scene thông qua `SpriteRenderer` và chỉ xử lý việc hiển thị. Các thao tác kéo/thả và cập nhật dữ liệu đã được chuyển sang `ItemController`.


### PR DESCRIPTION
## Summary
- expose icon and visibility logic from `ItemData`
- keep `ItemView` focused on rendering by reading from `ItemData`
- document the updated responsibilities of each Item MVC class

## Testing
- `No tests available`