### PR TITLE
Update item highlight using boolean

### DIFF
--- a/GoodSort/Assets/Scripts/Controller/ItemController.cs
+++ b/GoodSort/Assets/Scripts/Controller/ItemController.cs
@@ -14,23 +14,11 @@ namespace GameCore
         private SlotView m_curSlot;
         private Action<int, Vector2Int, Vector2Int> m_updateBoardChange;
 
-        [SerializeField] private int m_layerIndex;
-
 
         public int Id => m_itemData.id;
         public SlotView CurrentSlot => m_curSlot;
         public ShelfView CurrentShelf => m_curShelf;
 
-        public int LayerIndex
-        {
-            get => m_layerIndex;
-            set
-            {
-                if (m_layerIndex == value) return;
-                m_layerIndex = value;
-                m_view.SetLayer(m_layerIndex);
-            }
-        }
 
         private void Awake()
         {
@@ -44,8 +32,13 @@ namespace GameCore
             m_itemData = data;
             m_curShelf = shelfView;
             m_curSlot = slotView;
-            LayerIndex = layerIndex;
             m_view.SetupView(data);
+            SetLayer(layerIndex, layerIndex == 1);
+        }
+
+        public void SetLayer(int layerIndex, bool isTopItem)
+        {
+            m_view.SetLayer(layerIndex, isTopItem);
         }
 
 

--- a/GoodSort/Assets/Scripts/View/ItemView.cs
+++ b/GoodSort/Assets/Scripts/View/ItemView.cs
@@ -9,7 +9,7 @@ namespace GameCore
         [SerializeField] private SpriteRenderer m_icon;
         [SerializeField] private Collider2D m_collider;
         [SerializeField] private float m_heightOffset;
-        [SerializeField] private int m_layerIndex;
+        public bool isTopItem;
 
         public void SetupView(ItemData data)
         {
@@ -20,16 +20,16 @@ namespace GameCore
             }
         }
 
-        public void SetLayer(int layerIndex)
+        public void SetLayer(int layerIndex, bool isTop)
         {
-            m_layerIndex = layerIndex;
+            isTopItem = isTop;
             if (m_icon != null)
             {
-                m_icon.color = layerIndex == 1 ? Color.white : Color.gray;
+                m_icon.color = isTopItem ? Color.white : Color.gray;
                 m_icon.sortingOrder = 10 - layerIndex;
             }
             transform.localPosition = new Vector3(transform.localPosition.x, (layerIndex - 1) * m_heightOffset, 0f);
-            SetActiveItem(layerIndex == 1);
+            SetActiveItem(isTopItem);
         }
 
 

--- a/GoodSort/Assets/Scripts/View/ShelfView.cs
+++ b/GoodSort/Assets/Scripts/View/ShelfView.cs
@@ -178,7 +178,7 @@ namespace GameCore
             {
                 foreach (var item in itemLayer.Value)
                 {
-                    item.LayerIndex = itemLayer.Key + 1;
+                    item.SetLayer(itemLayer.Key + 1, itemLayer.Key == 0);
                 }
             }
         }

--- a/GoodSort/Assets/Scripts/View/SlotView.cs
+++ b/GoodSort/Assets/Scripts/View/SlotView.cs
@@ -73,7 +73,7 @@ namespace GameCore
                 var item = transform.GetChild(i).GetComponent<ItemController>();
                 if (item != null)
                 {
-                    item.LayerIndex = i + 1;
+                    item.SetLayer(i + 1, i == 0);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a public `isTopItem` flag in `ItemView`
- color items based on `isTopItem` instead of layer index
- remove `LayerIndex` property from `ItemController`
- adjust `SlotView` and `ShelfView` to set layer and top-item flag

## Testing
- `npm test` *(fails: ENOENT, no package.json)*
- `pytest` *(no tests found)*
- `dotnet test` *(fails: command not found)*